### PR TITLE
Fixes issue 20

### DIFF
--- a/internal/web/helpers.go
+++ b/internal/web/helpers.go
@@ -160,9 +160,11 @@ func runScriptWithStdIn(responseWriter http.ResponseWriter, scriptToRun ScriptEx
 	runningProcesses.mutex.Unlock()
 
 	processKiller := time.AfterFunc(timeout, func() {
-		command.Process.Kill()
-		logwrapper.LogWarningf("Request Timed Out. Timeout: '%s'; Command: '%s'; Arguments: %#v", timeout, scriptToRun.Path, scriptToRun.Args)
-		timeoutOccured = true
+		if command.Process != nil {
+			command.Process.Kill()
+			logwrapper.LogWarningf("Request Timed Out. Timeout: '%s'; Command: '%s'; Arguments: %#v", timeout, scriptToRun.Path, scriptToRun.Args)
+			timeoutOccured = true
+		}
 	})
 
 	output, errorVariable := command.CombinedOutput()


### PR DESCRIPTION
It appears that when the server is under extreme IO load there is a race condition where the process doesn't get started, this causes a panic: runtime error: invalid memory address or nil pointer dereference which terminates the process/service.