### PR TITLE
Making -version independent of the configuration file

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -149,7 +149,7 @@ jobs:
           pushd ${{ env.SRCPATH }}
           
           GO111MODULE=on GOOS=$os GOARCH=$arch go get ./...
-          GO111MODULE=on GOOS=$os GOARCH=$arch go build -ldflags "-X monitoringagent/internal/configuration.maVersion=${{needs.get-version-number.outputs.version}} -X monitoringagent/internal/configuration.operatingSystem=${{ matrix.os }} -X monitoringagent/internal/configuration.arch=${{ matrix.arch }} -X monitoringagent/internal/configuration.goVersion=Go${{ matrix.go-version }}" -o ${{ env.SRCPATH }}/monitoring-agent$suffix
+          GO111MODULE=on GOOS=$os GOARCH=$arch go build -ldflags "-X monitoringagent/main.maVersion=${{needs.get-version-number.outputs.version}} -X monitoringagent/main.operatingSystem=${{ matrix.os }} -X monitoringagent/main.arch=${{ matrix.arch }} -X monitoringagent/main.goVersion=Go${{ matrix.go-version }}" -o ${{ env.SRCPATH }}/monitoring-agent$suffix
           popd
           cp ${{ env.SRCPATH }}/monitoring-agent$suffix ./release/monitoring-agent-${{ matrix.os }}-${{ matrix.arch }}-Go${{ matrix.go-version }}-${{needs.get-version-number.outputs.version}}-BIN/monitoring-agent$suffix
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -149,7 +149,7 @@ jobs:
           pushd ${{ env.SRCPATH }}
           
           GO111MODULE=on GOOS=$os GOARCH=$arch go get ./...
-          GO111MODULE=on GOOS=$os GOARCH=$arch go build -ldflags "-X monitoringagent/main.maVersion=${{needs.get-version-number.outputs.version}} -X monitoringagent/main.operatingSystem=${{ matrix.os }} -X monitoringagent/main.arch=${{ matrix.arch }} -X monitoringagent/main.goVersion=Go${{ matrix.go-version }}" -o ${{ env.SRCPATH }}/monitoring-agent$suffix
+          GO111MODULE=on GOOS=$os GOARCH=$arch go build -ldflags "-X main.maVersion=${{needs.get-version-number.outputs.version}} -X main.operatingSystem=${{ matrix.os }} -X main.arch=${{ matrix.arch }} -X main.goVersion=Go${{ matrix.go-version }}" -o ${{ env.SRCPATH }}/monitoring-agent$suffix
           popd
           cp ${{ env.SRCPATH }}/monitoring-agent$suffix ./release/monitoring-agent-${{ matrix.os }}-${{ matrix.arch }}-Go${{ matrix.go-version }}-${{needs.get-version-number.outputs.version}}-BIN/monitoring-agent$suffix
 

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -9,9 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/jedisct1/go-minisign"
@@ -23,15 +21,8 @@ var Settings = Config{}
 // ConfigurationDirectory represents the path to the JSON configuration file
 var ConfigurationDirectory string
 
-var maVersion string = "0.0.0"
-var operatingSystem string = runtime.GOOS
-var arch string = runtime.GOARCH
-var goVersion = ""
-
-//var version string = "0.0.0 \n" + runtime.GOOS + " " + runtime.GOARCH + "\n" + runtime.Version()
-
 // Initialise loads the settings from the configurationfile
-func Initialise(configurationDirectory string) {
+func Initialise(configurationDirectory string, monitoringAgentVersionString string) {
 
 	paths := InitialisePaths(configurationDirectory)
 
@@ -46,7 +37,7 @@ func Initialise(configurationDirectory string) {
 		panic(err)
 	}
 
-	Settings.MonitoringAgentVersion = strings.Join([]string{"monitoring-agent " + maVersion, operatingSystem + " " + arch, goVersion}, "; ")
+	Settings.MonitoringAgentVersion = monitoringAgentVersionString
 
 	Settings.Paths.Reset(paths)
 }
@@ -57,7 +48,7 @@ func TestingInitialise() {
 	configurationDirectoryTemp, _ := os.Getwd()
 	configurationDirectory := filepath.FromSlash(configurationDirectoryTemp + "/../../")
 
-	Initialise(configurationDirectory)
+	Initialise(configurationDirectory, "monitoring-agent 0.0.0.0")
 
 	Settings.Server.BindAddress = "127.0.0.1:9000"
 	Settings.Server.HTTPRequestTimeout.Duration = time.Second * 11

--- a/main.go
+++ b/main.go
@@ -8,9 +8,16 @@ import (
 	"monitoringagent/internal/web"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/kardianos/service"
 )
+
+var maVersion string = "0.0.0"
+var operatingSystem string = runtime.GOOS
+var arch string = runtime.GOARCH
+var goVersion = ""
 
 type program struct{}
 
@@ -77,12 +84,14 @@ func main() {
 	showVersion := flag.Bool("version", false, "Show version number and exit")
 	flag.Parse()
 
-	configuration.Initialise(configurationDirectory(configDirectory))
+	monitoringAgentVersionString := strings.Join([]string{"monitoring-agent " + maVersion, operatingSystem + " " + arch, goVersion}, "; ")
 
 	if *showVersion {
-		fmt.Printf("%s\n", configuration.Settings.MonitoringAgentVersion)
+		fmt.Printf("%s\n", monitoringAgentVersionString)
 		os.Exit(0)
 	}
+
+	configuration.Initialise(configurationDirectory(configDirectory), monitoringAgentVersionString)
 
 	logFile, _ := os.OpenFile(configuration.Settings.Logging.LogFilePath+".stdout", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0755)
 	redirectStderr(logFile)


### PR DESCRIPTION
Previously, if you had just the executable for monitoring-agent it would crash when executed with -version if it can't find a configuration file. I think the version should _always_ work irrespective of the environment in which monitoring-agent is executed