### PR TITLE
Add a 1 second delay into performance counter sampling

### DIFF
--- a/internal/web/apiv1_os_specific_windows.go
+++ b/internal/web/apiv1_os_specific_windows.go
@@ -3,6 +3,7 @@ package web
 import (
 	"errors"
 	"fmt"
+	"time"
 	"unsafe"
 
 	"github.com/lxn/win"
@@ -17,7 +18,7 @@ type OSSpecificResult struct {
 type OSSpecificResultItem struct {
 	CounterName  string
 	InstanceName string
-	Value string
+	Value        string
 }
 
 func getResult(osspecificrequest OSSpecificRequest) (OSSpecificResult, error) {
@@ -54,6 +55,8 @@ func ReadPerformanceCounter(counter string) (OSSpecificResult, error) {
 	if ret != win.ERROR_SUCCESS {
 		return returnvalue, fmt.Errorf("got an error: 0x%x", ret)
 	}
+
+	time.Sleep(1 * time.Second)
 
 	ret = win.PdhCollectQueryData(queryHandle)
 	if ret == win.ERROR_SUCCESS {


### PR DESCRIPTION
According to the MSDN documentation for the .NET abstraction
(https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.performancecounter.nextvalue?redirectedfrom=MSDN&view=dotnet-plat-ext-7.0#System_Diagnostics_PerformanceCounter_NextValue) it seems like some performance counters are calculated based on rates of change and stuff. This basically means that you need to sample the counter several times with a delay inbetween, otherwise you get 0 (like we were before).

Fixes #27